### PR TITLE
Use `object_base` in config

### DIFF
--- a/config/GP6E01/config.yml
+++ b/config/GP6E01/config.yml
@@ -1,836 +1,837 @@
 # See config.example.yml for documentation.
-object: orig/GP6E01/sys/main.dol
+object_base: orig/GP6E01
+object: sys/main.dol
 hash: b897e6ade6b3a0cd2f9907689f38a3b19c327e70
 symbols: config/GP6E01/symbols.txt
 splits: config/GP6E01/splits.txt
-# Change this to match the linker verison.
+# Change this to match the linker version.
 # See config.example.yml for a list.
 mw_comment_version: 11
 
 modules:
-- object: orig/GP6E01/files/dll/m699Dll.rel
+- object: files/dll/m699Dll.rel
   hash: 714aa2732f6ccb5c74f164ccd0de853bfea90f25
   symbols: config/dll/rels/m699Dll/symbols.txt
   splits: config/dll/rels/m699Dll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/m649Dll.rel
+- object: files/dll/m649Dll.rel
   hash: bfd1a5c5fc795d82a153c8d4490323f9e4f87105
   symbols: config/dll/rels/m649Dll/symbols.txt
   splits: config/dll/rels/m649Dll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/jbtestdll.rel
+- object: files/dll/jbtestdll.rel
   hash: 59bc7b8cc021c5bcba482f81ba51e3a8766f215e
   symbols: config/dll/rels/jbtestdll/symbols.txt
   splits: config/dll/rels/jbtestdll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/m657Dll.rel
+- object: files/dll/m657Dll.rel
   hash: 89ec301525ca16e3b57cd5ac8bec6dc03188fba8
   symbols: config/dll/rels/m657Dll/symbols.txt
   splits: config/dll/rels/m657Dll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/m625Dll.rel
+- object: files/dll/m625Dll.rel
   hash: d98b833c78f0e4df64d943846b39ec6a1241bcd6
   symbols: config/dll/rels/m625Dll/symbols.txt
   splits: config/dll/rels/m625Dll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/m610DLL.rel
+- object: files/dll/m610DLL.rel
   hash: 919723b2e79ebd3aaa119a7889b1fdf4614fef62
   symbols: config/dll/rels/m610DLL/symbols.txt
   splits: config/dll/rels/m610DLL/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/m644dll.rel
+- object: files/dll/m644dll.rel
   hash: f11cf567a66b1e3f42713a3e9fe69e2b900e80da
   symbols: config/dll/rels/m644dll/symbols.txt
   splits: config/dll/rels/m644dll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/m666dll.rel
+- object: files/dll/m666dll.rel
   hash: 9afbbbbfb7e378e3ebeb02d63a42264690b7035e
   symbols: config/dll/rels/m666dll/symbols.txt
   splits: config/dll/rels/m666dll/splits.txt
   links: []
 
-# - object: orig/GP6E01/files/dll/m580Dll.rel
+# - object: files/dll/m580Dll.rel
 #   hash: acffec5b3084b0487d4bad22e15e797c7c8d7434
 #   symbols: config/dll/rels/m580Dll/symbols.txt
 #   splits: config/dll/rels/m580Dll/splits.txt
 #   links: []
 
-- object: orig/GP6E01/files/dll/m535Dll.rel
+- object: files/dll/m535Dll.rel
   hash: 5a69f0a8ec04a5badf89f9d02e03f66a2e0eaff5
   symbols: config/dll/rels/m535Dll/symbols.txt
   splits: config/dll/rels/m535Dll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/mdpartydll.rel
+- object: files/dll/mdpartydll.rel
   hash: 519debb149ef42eda1ab3b0a4d2b3132b4f3e3cc
   symbols: config/dll/rels/mdpartydll/symbols.txt
   splits: config/dll/rels/mdpartydll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/m628DLL.rel
+- object: files/dll/m628DLL.rel
   hash: 66b549dfb9a7f203bfb5e093f0380ed795cf9a24
   symbols: config/dll/rels/m628DLL/symbols.txt
   splits: config/dll/rels/m628DLL/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/meschkdll.rel
+- object: files/dll/meschkdll.rel
   hash: 382485dd0d423aad61c3d185e81336dde598353a
   symbols: config/dll/rels/meschkdll/symbols.txt
   splits: config/dll/rels/meschkdll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/actmanDLL.rel
+- object: files/dll/actmanDLL.rel
   hash: 1f3a9b96bf7a26918228ba3b776df28567ef3a97
   symbols: config/dll/rels/actmanDLL/symbols.txt
   splits: config/dll/rels/actmanDLL/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/m641Dll.rel
+- object: files/dll/m641Dll.rel
   hash: 1a4aad713cdae50721b34bf3ad0a673fead2ff23
   symbols: config/dll/rels/m641Dll/symbols.txt
   splits: config/dll/rels/m641Dll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/safdll.rel
+- object: files/dll/safdll.rel
   hash: 1a20e0b63c0bdf83d1ceebc05a055beb4d2a7748
   symbols: config/dll/rels/safdll/symbols.txt
   splits: config/dll/rels/safdll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/resultDll.rel
+- object: files/dll/resultDll.rel
   hash: 01d66826afb8b7005d2a9a54096984df3f59fb15
   symbols: config/dll/rels/resultDll/symbols.txt
   splits: config/dll/rels/resultDll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/mdminidll.rel
+- object: files/dll/mdminidll.rel
   hash: 468f09c0e12d8d0a27476d9d123ab61f9023acd5
   symbols: config/dll/rels/mdminidll/symbols.txt
   splits: config/dll/rels/mdminidll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/s03Dll.rel
+- object: files/dll/s03Dll.rel
   hash: 2d3ab4d5692ce8009c562b66f15955eef8f20bda
   symbols: config/dll/rels/s03Dll/symbols.txt
   splits: config/dll/rels/s03Dll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/w01Dll.rel
+- object: files/dll/w01Dll.rel
   hash: 196d7075abbe6eec3031c9484d25216de9dc0889
   symbols: config/dll/rels/w01Dll/symbols.txt
   splits: config/dll/rels/w01Dll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/m627dll.rel
+- object: files/dll/m627dll.rel
   hash: f0af1595f9ae74ad50fe3664a8cc49228426f68b
   symbols: config/dll/rels/m627dll/symbols.txt
   splits: config/dll/rels/m627dll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/micquizdll.rel
+- object: files/dll/micquizdll.rel
   hash: 22e7be6848dfcb9a436ff4ea0c3c54817293c2e1
   symbols: config/dll/rels/micquizdll/symbols.txt
   splits: config/dll/rels/micquizdll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/mdsingdll.rel
+- object: files/dll/mdsingdll.rel
   hash: badae36c280f8f5943bedde8ead4acb09139417f
   symbols: config/dll/rels/mdsingdll/symbols.txt
   splits: config/dll/rels/mdsingdll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/m603DLL.rel
+- object: files/dll/m603DLL.rel
   hash: d4833dd119a4f6d1f6ac78dc4b19da10cb0de8bd
   symbols: config/dll/rels/m603DLL/symbols.txt
   splits: config/dll/rels/m603DLL/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/w03Dll.rel
+- object: files/dll/w03Dll.rel
   hash: e3f80fa8c173baf21ec7d12e1dbb8ab9ab302944
   symbols: config/dll/rels/w03Dll/symbols.txt
   splits: config/dll/rels/w03Dll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/w04Dll.rel
+- object: files/dll/w04Dll.rel
   hash: e3fa8815ea878e6b5b92feea4faec09f30d7a1de
   symbols: config/dll/rels/w04Dll/symbols.txt
   splits: config/dll/rels/w04Dll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/w10Dll.rel
+- object: files/dll/w10Dll.rel
   hash: ce6de1323caf83e84c96df02d106237040ce9cc0
   symbols: config/dll/rels/w10Dll/symbols.txt
   splits: config/dll/rels/w10Dll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/mdbankdll.rel
+- object: files/dll/mdbankdll.rel
   hash: a1f9c9f9f8dfb62ffbfbb75f7155c3ff38b4df79
   symbols: config/dll/rels/mdbankdll/symbols.txt
   splits: config/dll/rels/mdbankdll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/m634DLL.rel
+- object: files/dll/m634DLL.rel
   hash: b717e766763132f3be3d5b38962bbbd2fca776cb
   symbols: config/dll/rels/m634DLL/symbols.txt
   splits: config/dll/rels/m634DLL/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/m613Dll.rel
+- object: files/dll/m613Dll.rel
   hash: 6b6f7c1b47b143dbb627f251a768725f0a0a4f42
   symbols: config/dll/rels/m613Dll/symbols.txt
   splits: config/dll/rels/m613Dll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/micquizseldll.rel
+- object: files/dll/micquizseldll.rel
   hash: b7545e4275735313325dcf61246d18a177376957
   symbols: config/dll/rels/micquizseldll/symbols.txt
   splits: config/dll/rels/micquizseldll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/m665dll.rel
+- object: files/dll/m665dll.rel
   hash: 01ef22830a574945ad70fc213bd2794351b7727c
   symbols: config/dll/rels/m665dll/symbols.txt
   splits: config/dll/rels/m665dll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/micquizohdedll.rel
+- object: files/dll/micquizohdedll.rel
   hash: 724dfc0636a620d8c0a4d2c2c950bdb44a366065
   symbols: config/dll/rels/micquizohdedll/symbols.txt
   splits: config/dll/rels/micquizohdedll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/m630dll.rel
+- object: files/dll/m630dll.rel
   hash: 4208b57415ca83072bbc0390c32ccc844e1d5fa7
   symbols: config/dll/rels/m630dll/symbols.txt
   splits: config/dll/rels/m630dll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/m622DLL.rel
+- object: files/dll/m622DLL.rel
   hash: 3c136580ce230d5684c14e62f84973baa8d472be
   symbols: config/dll/rels/m622DLL/symbols.txt
   splits: config/dll/rels/m622DLL/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/mdseldll.rel
+- object: files/dll/mdseldll.rel
   hash: e6c20b24cfca8135ed8c49ce59108100277444c0
   symbols: config/dll/rels/mdseldll/symbols.txt
   splits: config/dll/rels/mdseldll/splits.txt
   links: []
 
-# - object: orig/GP6E01/files/dll/m433Dll.rel
+# - object: files/dll/m433Dll.rel
 #   hash: 6b417d96fd14d3b22bbc42601078ff38c995123f
 #   symbols: config/dll/rels/m433Dll/symbols.txt
 #   splits: config/dll/rels/m433Dll/splits.txt
 #   links: []
 
-- object: orig/GP6E01/files/dll/fileseldll.rel
+- object: files/dll/fileseldll.rel
   hash: 98ffdca10a6b0f9d5e5fcd526b65816306ea808e
   symbols: config/dll/rels/fileseldll/symbols.txt
   splits: config/dll/rels/fileseldll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/m648DLL.rel
+- object: files/dll/m648DLL.rel
   hash: 04a7b220b153739d17652dafb80903f6adcac053
   symbols: config/dll/rels/m648DLL/symbols.txt
   splits: config/dll/rels/m648DLL/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/sequencedll.rel
+- object: files/dll/sequencedll.rel
   hash: 1b605556f4e379b8d3a2c9b3669b29b2949d0233
   symbols: config/dll/rels/sequencedll/symbols.txt
   splits: config/dll/rels/sequencedll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/w05Dll.rel
+- object: files/dll/w05Dll.rel
   hash: ceaf57649354c6b735c2f8e4ef45e655045fb8fa
   symbols: config/dll/rels/w05Dll/symbols.txt
   splits: config/dll/rels/w05Dll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/m654DLL.rel
+- object: files/dll/m654DLL.rel
   hash: 1f69ce5e3ec7ad5dadbc98a699c0d9e6b13a8892
   symbols: config/dll/rels/m654DLL/symbols.txt
   splits: config/dll/rels/m654DLL/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/m673DLL.rel
+- object: files/dll/m673DLL.rel
   hash: ede9954027cdf07b8d8d2cd7039f1a2a336e0db5
   symbols: config/dll/rels/m673DLL/symbols.txt
   splits: config/dll/rels/m673DLL/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/mgmfreedll.rel
+- object: files/dll/mgmfreedll.rel
   hash: 949e6695d4d9f413b8690414b9b2021e983159bc
   symbols: config/dll/rels/mgmfreedll/symbols.txt
   splits: config/dll/rels/mgmfreedll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/motchkDll.rel
+- object: files/dll/motchkDll.rel
   hash: 444d1cbe2e388b4794f8b268328bfb64678ad21d
   symbols: config/dll/rels/motchkDll/symbols.txt
   splits: config/dll/rels/motchkDll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/mgmrenshodll.rel
+- object: files/dll/mgmrenshodll.rel
   hash: 61042b2a9a76591e4b90eb8c96c07dec931cf4e0
   symbols: config/dll/rels/mgmrenshodll/symbols.txt
   splits: config/dll/rels/mgmrenshodll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/optionDll.rel
+- object: files/dll/optionDll.rel
   hash: 9a22952d087a80920ca844c0cd2b22bf620489ec
   symbols: config/dll/rels/optionDll/symbols.txt
   splits: config/dll/rels/optionDll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/m640dll.rel
+- object: files/dll/m640dll.rel
   hash: ffd43e831a60f9dc378bffde9d43f064b6a0fa85
   symbols: config/dll/rels/m640dll/symbols.txt
   splits: config/dll/rels/m640dll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/m680Dll.rel
+- object: files/dll/m680Dll.rel
   hash: 528b2d727c5b8b48d4c09808ad00275183c4100d
   symbols: config/dll/rels/m680Dll/symbols.txt
   splits: config/dll/rels/m680Dll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/m541Dll.rel
+- object: files/dll/m541Dll.rel
   hash: 5a69f0a8ec04a5badf89f9d02e03f66a2e0eaff5
   symbols: config/dll/rels/m541Dll/symbols.txt
   splits: config/dll/rels/m541Dll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/m619Dll.rel
+- object: files/dll/m619Dll.rel
   hash: 368f0447f35bbbab2bf0c5dfe65196931feef4d0
   symbols: config/dll/rels/m619Dll/symbols.txt
   splits: config/dll/rels/m619Dll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/m667dll.rel
+- object: files/dll/m667dll.rel
   hash: 6a289d8322aab7a45a11e44031e298028fa5b243
   symbols: config/dll/rels/m667dll/symbols.txt
   splits: config/dll/rels/m667dll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/m618dll.rel
+- object: files/dll/m618dll.rel
   hash: 4eaa9f7d77a55fe361e7083b1b291462c8b79fe5
   symbols: config/dll/rels/m618dll/symbols.txt
   splits: config/dll/rels/m618dll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/mgmbingodll.rel
+- object: files/dll/mgmbingodll.rel
   hash: 60733649b11154381d193395e9a0676c1b91e86a
   symbols: config/dll/rels/mgmbingodll/symbols.txt
   splits: config/dll/rels/mgmbingodll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/partyresultdll.rel
+- object: files/dll/partyresultdll.rel
   hash: 0ce006614eeeaace822f0251cc106fd1b69ca431
   symbols: config/dll/rels/partyresultdll/symbols.txt
   splits: config/dll/rels/partyresultdll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/m653DLL.rel
+- object: files/dll/m653DLL.rel
   hash: ce8e756009eb869f26289efd79fee651193e299f
   symbols: config/dll/rels/m653DLL/symbols.txt
   splits: config/dll/rels/m653DLL/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/m652DLL.rel
+- object: files/dll/m652DLL.rel
   hash: 9d94657c4252b20829125e14086082e17bb803d7
   symbols: config/dll/rels/m652DLL/symbols.txt
   splits: config/dll/rels/m652DLL/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/m638Dll.rel
+- object: files/dll/m638Dll.rel
   hash: 536d0631871e5da391797df5a268d0974ad82939
   symbols: config/dll/rels/m638Dll/symbols.txt
   splits: config/dll/rels/m638Dll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/m643DLL.rel
+- object: files/dll/m643DLL.rel
   hash: 2cbcc14069b192a9d5a8cb99cfce0eeb7f84f923
   symbols: config/dll/rels/m643DLL/symbols.txt
   splits: config/dll/rels/m643DLL/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/m672DLL.rel
+- object: files/dll/m672DLL.rel
   hash: 43873e26bfb41529a094581f00e8ea729f090698
   symbols: config/dll/rels/m672DLL/symbols.txt
   splits: config/dll/rels/m672DLL/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/mgmbattledll.rel
+- object: files/dll/mgmbattledll.rel
   hash: dc6033724afb5bb7e96dedc93ca10dd48d917605
   symbols: config/dll/rels/mgmbattledll/symbols.txt
   splits: config/dll/rels/mgmbattledll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/mgmtournamentdll.rel
+- object: files/dll/mgmtournamentdll.rel
   hash: dd44153cc0937b5f219f16694c66a898aec81548
   symbols: config/dll/rels/mgmtournamentdll/symbols.txt
   splits: config/dll/rels/mgmtournamentdll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/m620Dll.rel
+- object: files/dll/m620Dll.rel
   hash: 6e25e354c44c848ece5817253c64e2577184f3a7
   symbols: config/dll/rels/m620Dll/symbols.txt
   splits: config/dll/rels/m620Dll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/m677DLL.rel
+- object: files/dll/m677DLL.rel
   hash: 9466e83605f5cffab6f7cc057a2a0e68feff17eb
   symbols: config/dll/rels/m677DLL/symbols.txt
   splits: config/dll/rels/m677DLL/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/m606Dll.rel
+- object: files/dll/m606Dll.rel
   hash: afbbbaa144c40dfa973fe5e479e5a4b15019d768
   symbols: config/dll/rels/m606Dll/symbols.txt
   splits: config/dll/rels/m606Dll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/m605DLL.rel
+- object: files/dll/m605DLL.rel
   hash: abf8f5acff51b18e90f678bea2ed5abf2103ce8b
   symbols: config/dll/rels/m605DLL/symbols.txt
   splits: config/dll/rels/m605DLL/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/m662dll.rel
+- object: files/dll/m662dll.rel
   hash: cc74ed6d5e8e21d66bacc952bd92b0cd70fa4c14
   symbols: config/dll/rels/m662dll/symbols.txt
   splits: config/dll/rels/m662dll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/m681DLL.rel
+- object: files/dll/m681DLL.rel
   hash: 969966b2e377b8019428aa8dad9b527e4d4b67c5
   symbols: config/dll/rels/m681DLL/symbols.txt
   splits: config/dll/rels/m681DLL/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/m607DLL.rel
+- object: files/dll/m607DLL.rel
   hash: edd44f88528c1186db47e75e654358b3e62ecf9e
   symbols: config/dll/rels/m607DLL/symbols.txt
   splits: config/dll/rels/m607DLL/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/bootDll.rel
+- object: files/dll/bootDll.rel
   hash: c2903001e92092befe2c84ebb389d10126f42064
   symbols: config/dll/rels/bootDll/symbols.txt
   splits: config/dll/rels/bootDll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/m604DLL.rel
+- object: files/dll/m604DLL.rel
   hash: 227c25eafd5f444e52629f77b6c10f352453429b
   symbols: config/dll/rels/m604DLL/symbols.txt
   splits: config/dll/rels/m604DLL/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/m664dll.rel
+- object: files/dll/m664dll.rel
   hash: fc0913bdd1baa9d40c334af0f242acca42fd5710
   symbols: config/dll/rels/m664dll/symbols.txt
   splits: config/dll/rels/m664dll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/m635dll.rel
+- object: files/dll/m635dll.rel
   hash: 9b4982ca273693a9d13e844febe5c20a5dee8164
   symbols: config/dll/rels/m635dll/symbols.txt
   splits: config/dll/rels/m635dll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/m642dll.rel
+- object: files/dll/m642dll.rel
   hash: 3caf0ba50e19b90d9b8e8338f7ed42c5b0e25203
   symbols: config/dll/rels/m642dll/symbols.txt
   splits: config/dll/rels/m642dll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/w06Dll.rel
+- object: files/dll/w06Dll.rel
   hash: 7129e9c13be295925cec74e1515564cf2af20fb8
   symbols: config/dll/rels/w06Dll/symbols.txt
   splits: config/dll/rels/w06Dll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/m646Dll.rel
+- object: files/dll/m646Dll.rel
   hash: c37092a4500e0ae8ac16dd31270262c589d15327
   symbols: config/dll/rels/m646Dll/symbols.txt
   splits: config/dll/rels/m646Dll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/mdmicdll.rel
+- object: files/dll/mdmicdll.rel
   hash: fdf2029a4082fe5f56acbe6cda0351400dec8399
   symbols: config/dll/rels/mdmicdll/symbols.txt
   splits: config/dll/rels/mdmicdll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/m612dll.rel
+- object: files/dll/m612dll.rel
   hash: 72eaf68e20680735b0ad463a6739f508e2c51427
   symbols: config/dll/rels/m612dll/symbols.txt
   splits: config/dll/rels/m612dll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/m645DLL.rel
+- object: files/dll/m645DLL.rel
   hash: 11511d5bd9717dd7c40c6380078d7abed0309181
   symbols: config/dll/rels/m645DLL/symbols.txt
   splits: config/dll/rels/m645DLL/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/micquizmyokodll.rel
+- object: files/dll/micquizmyokodll.rel
   hash: 4ebd958e015166eb154cc25972a88ab62c39ba24
   symbols: config/dll/rels/micquizmyokodll/symbols.txt
   splits: config/dll/rels/micquizmyokodll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/m655DLL.rel
+- object: files/dll/m655DLL.rel
   hash: fca9ca0da44954aa86c70011fb4bbf72c5de5fb5
   symbols: config/dll/rels/m655DLL/symbols.txt
   splits: config/dll/rels/m655DLL/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/openingDll.rel
+- object: files/dll/openingDll.rel
   hash: 1de89dc139c7292294ad4c28536754617265a58a
   symbols: config/dll/rels/openingDll/symbols.txt
   splits: config/dll/rels/openingDll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/m626Dll.rel
+- object: files/dll/m626Dll.rel
   hash: 3757ef300ed081b23494cf302c175214a78c082c
   symbols: config/dll/rels/m626Dll/symbols.txt
   splits: config/dll/rels/m626Dll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/m633dll.rel
+- object: files/dll/m633dll.rel
   hash: 16679fbbda0212dc5c1c2dbcc9e415f1b18f2783
   symbols: config/dll/rels/m633dll/symbols.txt
   splits: config/dll/rels/m633dll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/m609dll.rel
+- object: files/dll/m609dll.rel
   hash: e0afe6441eff2a0be5b3121a245b5dca24dda113
   symbols: config/dll/rels/m609dll/symbols.txt
   splits: config/dll/rels/m609dll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/selmenuDll.rel
+- object: files/dll/selmenuDll.rel
   hash: 7bc5aa5991425fdb03153f1611a39bb5fa8e0cd7
   symbols: config/dll/rels/selmenuDll/symbols.txt
   splits: config/dll/rels/selmenuDll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/mikeactdll.rel
+- object: files/dll/mikeactdll.rel
   hash: c6bea5bda5bd51fe8a586f816096a0873a62c18d
   symbols: config/dll/rels/mikeactdll/symbols.txt
   splits: config/dll/rels/mikeactdll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/m679dll.rel
+- object: files/dll/m679dll.rel
   hash: 10ef35a9edd8d370ba2bfd1a1bb37146ed67ddf3
   symbols: config/dll/rels/m679dll/symbols.txt
   splits: config/dll/rels/m679dll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/m571dll.rel
+- object: files/dll/m571dll.rel
   hash: 5a69f0a8ec04a5badf89f9d02e03f66a2e0eaff5
   symbols: config/dll/rels/m571dll/symbols.txt
   splits: config/dll/rels/m571dll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/m661dll.rel
+- object: files/dll/m661dll.rel
   hash: a8362d9464e85d854e01f0021330d756c5abd682
   symbols: config/dll/rels/m661dll/symbols.txt
   splits: config/dll/rels/m661dll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/m602Dll.rel
+- object: files/dll/m602Dll.rel
   hash: ffb3394155ef9cffac6b49fe0de21c2e7d20ead9
   symbols: config/dll/rels/m602Dll/symbols.txt
   splits: config/dll/rels/m602Dll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/m668DLL.rel
+- object: files/dll/m668DLL.rel
   hash: 4464e33731c47804f4eb912a7c62a6c4ec582bd8
   symbols: config/dll/rels/m668DLL/symbols.txt
   splits: config/dll/rels/m668DLL/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/m629Dll.rel
+- object: files/dll/m629Dll.rel
   hash: ac978fdea886b4c187c12c67478e5ef6084f96a5
   symbols: config/dll/rels/m629Dll/symbols.txt
   splits: config/dll/rels/m629Dll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/m670dll.rel
+- object: files/dll/m670dll.rel
   hash: 7ee329c60bce611da78491ae7fa0591a110d42b3
   symbols: config/dll/rels/m670dll/symbols.txt
   splits: config/dll/rels/m670dll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/miraclebookdll.rel
+- object: files/dll/miraclebookdll.rel
   hash: 12f5d0f8e5402d2f9071b6d11ab526804803bb1f
   symbols: config/dll/rels/miraclebookdll/symbols.txt
   splits: config/dll/rels/miraclebookdll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/m624DLL.rel
+- object: files/dll/m624DLL.rel
   hash: c05accc354eaa69f68c6a4bf8b49f680d66432bd
   symbols: config/dll/rels/m624DLL/symbols.txt
   splits: config/dll/rels/m624DLL/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/m637dll.rel
+- object: files/dll/m637dll.rel
   hash: 4ff78f1530b2c8119db7913c5c08c236f338643e
   symbols: config/dll/rels/m637dll/symbols.txt
   splits: config/dll/rels/m637dll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/m631Dll.rel
+- object: files/dll/m631Dll.rel
   hash: 35466850011d85091eee3f881eef9258b5e336cf
   symbols: config/dll/rels/m631Dll/symbols.txt
   splits: config/dll/rels/m631Dll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/w02Dll.rel
+- object: files/dll/w02Dll.rel
   hash: 8e65bce51c6650fa1c7fca8faa640d5a199a62d4
   symbols: config/dll/rels/w02Dll/symbols.txt
   splits: config/dll/rels/w02Dll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/m669DLL.rel
+- object: files/dll/m669DLL.rel
   hash: ec237202e80f326811a10c6182722b65795a1100
   symbols: config/dll/rels/m669DLL/symbols.txt
   splits: config/dll/rels/m669DLL/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/m678Dll.rel
+- object: files/dll/m678Dll.rel
   hash: 61be9fbdb5400493bde487ca654e87d7d67341a5
   symbols: config/dll/rels/m678Dll/symbols.txt
   splits: config/dll/rels/m678Dll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/s01Dll.rel
+- object: files/dll/s01Dll.rel
   hash: 7f0cfdb2d2b0b2c50b92675e5bef55d72cf94dd7
   symbols: config/dll/rels/s01Dll/symbols.txt
   splits: config/dll/rels/s01Dll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/m632dll.rel
+- object: files/dll/m632dll.rel
   hash: 13d3ade1c06e7088f86d3e2ec5b37faf6b4c41cb
   symbols: config/dll/rels/m632dll/symbols.txt
   splits: config/dll/rels/m632dll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/mgmdecathlondll.rel
+- object: files/dll/mgmdecathlondll.rel
   hash: 596d8ce6361387b92603933b31e3e77496c27300
   symbols: config/dll/rels/mgmdecathlondll/symbols.txt
   splits: config/dll/rels/mgmdecathlondll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/m658dll.rel
+- object: files/dll/m658dll.rel
   hash: 3e8d93277917aa99497acbcabe08852738c7c080
   symbols: config/dll/rels/m658dll/symbols.txt
   splits: config/dll/rels/m658dll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/m621dll.rel
+- object: files/dll/m621dll.rel
   hash: bac89aab23758eb5878822e3b4f1023d54bbd81c
   symbols: config/dll/rels/m621dll/symbols.txt
   splits: config/dll/rels/m621dll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/m639DLL.rel
+- object: files/dll/m639DLL.rel
   hash: 5657f922ecd5dffca49fb6883e7ccfd1c29c3daf
   symbols: config/dll/rels/m639DLL/symbols.txt
   splits: config/dll/rels/m639DLL/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/micquizishidll.rel
+- object: files/dll/micquizishidll.rel
   hash: f79d519bacdc40e10682c9c613697a7372567497
   symbols: config/dll/rels/micquizishidll/symbols.txt
   splits: config/dll/rels/micquizishidll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/storyresultdll.rel
+- object: files/dll/storyresultdll.rel
   hash: 0ce006614eeeaace822f0251cc106fd1b69ca431
   symbols: config/dll/rels/storyresultdll/symbols.txt
   splits: config/dll/rels/storyresultdll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/m656DLL.rel
+- object: files/dll/m656DLL.rel
   hash: c79933949ba2879eb3f0d9308d12b703c868ae6d
   symbols: config/dll/rels/m656DLL/symbols.txt
   splits: config/dll/rels/m656DLL/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/m671DLL.rel
+- object: files/dll/m671DLL.rel
   hash: 5d72e8b675356d5379137c5c53ed88924d3b97d3
   symbols: config/dll/rels/m671DLL/symbols.txt
   splits: config/dll/rels/m671DLL/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/m559dll.rel
+- object: files/dll/m559dll.rel
   hash: 5a69f0a8ec04a5badf89f9d02e03f66a2e0eaff5
   symbols: config/dll/rels/m559dll/symbols.txt
   splits: config/dll/rels/m559dll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/s02Dll.rel
+- object: files/dll/s02Dll.rel
   hash: 3de15e73407b1b1fa2e54f71ed02ec57538f6eb5
   symbols: config/dll/rels/s02Dll/symbols.txt
   splits: config/dll/rels/s02Dll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/m647dll.rel
+- object: files/dll/m647dll.rel
   hash: 87b31abcc1062dc835c4060e3f2a5aafa48c85e9
   symbols: config/dll/rels/m647dll/symbols.txt
   splits: config/dll/rels/m647dll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/m659Dll.rel
+- object: files/dll/m659Dll.rel
   hash: 9dd86ed2cb92ec83763409182dd8a63d8943b669
   symbols: config/dll/rels/m659Dll/symbols.txt
   splits: config/dll/rels/m659Dll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/m608dll.rel
+- object: files/dll/m608dll.rel
   hash: 2f36ce874692c318e5f312a80acb3d4755abcaf9
   symbols: config/dll/rels/m608dll/symbols.txt
   splits: config/dll/rels/m608dll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/ttwarsdll.rel
+- object: files/dll/ttwarsdll.rel
   hash: 459a170aed889b4975a90366996b1e1bf59c6185
   symbols: config/dll/rels/ttwarsdll/symbols.txt
   splits: config/dll/rels/ttwarsdll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/m674Dll.rel
+- object: files/dll/m674Dll.rel
   hash: affd18264578557ed84df2089ac75d0d2f294f6e
   symbols: config/dll/rels/m674Dll/symbols.txt
   splits: config/dll/rels/m674Dll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/endingdll.rel
+- object: files/dll/endingdll.rel
   hash: 305f3f2a81df64f0e7362d6befc663361fdba168
   symbols: config/dll/rels/endingdll/symbols.txt
   splits: config/dll/rels/endingdll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/m636dll.rel
+- object: files/dll/m636dll.rel
   hash: 5e5ec563a72408c259114889c15932616b32602f
   symbols: config/dll/rels/m636dll/symbols.txt
   splits: config/dll/rels/m636dll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/m611DLL.rel
+- object: files/dll/m611DLL.rel
   hash: db6ed9b7b23f71454361933decfff097257b47e2
   symbols: config/dll/rels/m611DLL/symbols.txt
   splits: config/dll/rels/m611DLL/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/m601Dll.rel
+- object: files/dll/m601Dll.rel
   hash: 4f00f7200e56540abe6129cbe8acf0d121afbe14
   symbols: config/dll/rels/m601Dll/symbols.txt
   splits: config/dll/rels/m601Dll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/m623DLL.rel
+- object: files/dll/m623DLL.rel
   hash: 0e6f879c946b278994b90ce75e4186f4ad8b38cb
   symbols: config/dll/rels/m623DLL/symbols.txt
   splits: config/dll/rels/m623DLL/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/m675Dll.rel
+- object: files/dll/m675Dll.rel
   hash: d51f407f4e0a0b327e6d42aeff93183bc2a2b45e
   symbols: config/dll/rels/m675Dll/symbols.txt
   splits: config/dll/rels/m675Dll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/w11Dll.rel
+- object: files/dll/w11Dll.rel
   hash: 7718483b2764d53433edbe72ca4abc3c686629bc
   symbols: config/dll/rels/w11Dll/symbols.txt
   splits: config/dll/rels/w11Dll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/m614Dll.rel
+- object: files/dll/m614Dll.rel
   hash: fab562d63e8ca316ebe5d415f49ce1f62f44813f
   symbols: config/dll/rels/m614Dll/symbols.txt
   splits: config/dll/rels/m614Dll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/mdpresultdll.rel
+- object: files/dll/mdpresultdll.rel
   hash: 1ebd831bd8e3ca6c15808287df6c820e1384306c
   symbols: config/dll/rels/mdpresultdll/symbols.txt
   splits: config/dll/rels/mdpresultdll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/m676Dll.rel
+- object: files/dll/m676Dll.rel
   hash: 8d847b399f52df8393544da9ba5261ee93967422
   symbols: config/dll/rels/m676Dll/symbols.txt
   splits: config/dll/rels/m676Dll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/m663dll.rel
+- object: files/dll/m663dll.rel
   hash: 0ccc4adbedc3349183cdb80769298c1b4becc130
   symbols: config/dll/rels/m663dll/symbols.txt
   splits: config/dll/rels/m663dll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/m651dll.rel
+- object: files/dll/m651dll.rel
   hash: 3be947b8ea59eb03d238b68df928249a53bf28d6
   symbols: config/dll/rels/m651dll/symbols.txt
   splits: config/dll/rels/m651dll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/m615DLL.rel
+- object: files/dll/m615DLL.rel
   hash: 4306e665873f30d0a4ea9fe5fd80c0db41e55ad7
   symbols: config/dll/rels/m615DLL/symbols.txt
   splits: config/dll/rels/m615DLL/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/staffdll.rel
+- object: files/dll/staffdll.rel
   hash: adbbd96733aa639d1b2845a537be2f6464d13da7
   symbols: config/dll/rels/staffdll/symbols.txt
   splits: config/dll/rels/staffdll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/instDll.rel
+- object: files/dll/instDll.rel
   hash: 28355214bae6f3ecf8ee79a89e3d23976bf5d5c8
   symbols: config/dll/rels/instDll/symbols.txt
   splits: config/dll/rels/instDll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/m660dll.rel
+- object: files/dll/m660dll.rel
   hash: ca06a01793781b8df81965dae433960d2385d142
   symbols: config/dll/rels/m660dll/symbols.txt
   splits: config/dll/rels/m660dll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/m617dll.rel
+- object: files/dll/m617dll.rel
   hash: 4608ff5bf628b2835ba59120f83b57551f4148e1
   symbols: config/dll/rels/m617dll/symbols.txt
   splits: config/dll/rels/m617dll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/m616dll.rel
+- object: files/dll/m616dll.rel
   hash: ae602cd9b8e9639c0d7c52b6ed553d2456c9cb3c
   symbols: config/dll/rels/m616dll/symbols.txt
   splits: config/dll/rels/m616dll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/m562dll.rel
+- object: files/dll/m562dll.rel
   hash: 5a69f0a8ec04a5badf89f9d02e03f66a2e0eaff5
   symbols: config/dll/rels/m562dll/symbols.txt
   splits: config/dll/rels/m562dll/splits.txt
   links: []
 
-- object: orig/GP6E01/files/dll/m650dll.rel
+- object: files/dll/m650dll.rel
   hash: 684b3826d70e7dc77fda0aeb66fafe4d11f9f1e0
   symbols: config/dll/rels/m650dll/symbols.txt
   splits: config/dll/rels/m650dll/splits.txt


### PR DESCRIPTION
Same change as https://github.com/mariopartyrd/marioparty7/pull/14 switching to `object_base`. For some reason unlike mp7 I can't get the build script to work here even with this change...